### PR TITLE
Fix class name for version 0.8.6

### DIFF
--- a/Formula/drone@0.8.6.rb
+++ b/Formula/drone@0.8.6.rb
@@ -1,6 +1,6 @@
 require File.expand_path("../../Abstract/abstract-drone", __FILE__)
 
-class DroneAT085 < AbstractDrone
+class DroneAT086 < AbstractDrone
   version "0.8.6"
   init
 end


### PR DESCRIPTION
`brew tap drone/drone` gets an error like below.

```
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/drone/homebrew-drone/Formula/drone@0.8.6.rb
No available formula with the name "drone@0.8.6" 
In formula file: /usr/local/Homebrew/Library/Taps/drone/homebrew-drone/Formula/drone@0.8.6.rb
Expected to find class DroneAT086, but only found: DroneAT085.
Error: Cannot tap drone/drone: invalid syntax in tap!
```

so I fixed class name.