### PR TITLE
Remove drone@0.5 formula

### DIFF
--- a/Formula/drone@0.5.rb
+++ b/Formula/drone@0.5.rb
@@ -1,8 +1,0 @@
-require File.expand_path("../../Abstract/abstract-drone", __FILE__)
-
-class DroneAT05 < AbstractDrone
-  version "0.5"
-  init
-  url "http://downloads.drone.io/0.5.0/release/darwin/amd64/drone.tar.gz"
-  sha256 `curl -s http://downloads.drone.io/0.5.0/release/darwin/amd64/drone.sha256`.split(' ').first
-end


### PR DESCRIPTION
Hello,

Running `brew tap drone/drone` currently fails with:
```
==> Tapping drone/drone
Cloning into '/usr/local/Homebrew/Library/Taps/drone/homebrew-drone'...
remote: Enumerating objects: 13, done.
remote: Counting objects: 100% (13/13), done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 220 (delta 6), reused 11 (delta 6), pack-reused 207
Receiving objects: 100% (220/220), 39.50 KiB | 652.00 KiB/s, done.
Resolving deltas: 100% (93/93), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/drone/homebrew-drone/Formula/drone@0.5.rb
drone@0.5: undefined method `downcase' for nil:NilClass
Error: Cannot tap drone/drone: invalid syntax in tap!
```

I believe this happens because http://downloads.drone.io/0.5.0/release/darwin/amd64/drone.tar.gz from https://github.com/drone/homebrew-drone/blob/3b7b1025d687f88d0b9623455a91e6defbed9ef1/Formula/drone%400.5.rb#L6 doesn't exist on the internet. Curl confirms that:
```
curl http://downloads.drone.io/
curl: (6) Could not resolve host: downloads.drone.io
```

As it stands, this tap is broken and anyone wanting to use it is unable to download any version of `drone` from it. Ideally, another link to the binary can replace this one, or this one can be restored - as I was unable to find a working link, I've removed the file entirely.

I've verified this works by running my own fork and tapping it locally, and I was then able to install the version of `drone` I wanted.